### PR TITLE
Replace FileTokenPersistence for the TokenPersistenceIterface

### DIFF
--- a/src/OAuth/Authorizator/Authorizator.php
+++ b/src/OAuth/Authorizator/Authorizator.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Namelivia\Fitbit\OAuth\Authorizator;
 
-use kamermans\OAuth2\Persistence\FileTokenPersistence;
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
 use Namelivia\Fitbit\OAuth\Config\Config;
 
 class Authorizator
 {
     public function __construct(
         Config $config,
-        FileTokenPersistence $tokenPersistence
+        TokenPersistenceInterface $tokenPersistence
     ) {
         $this->config = $config;
         $this->tokenPersistence = $tokenPersistence;

--- a/src/OAuth/Factory/Factory.php
+++ b/src/OAuth/Factory/Factory.php
@@ -6,14 +6,14 @@ namespace Namelivia\Fitbit\OAuth\Factory;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
-use kamermans\OAuth2\Persistence\FileTokenPersistence;
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
 use Namelivia\Fitbit\OAuth\Client\Client as OAuthClient;
 use Namelivia\Fitbit\OAuth\Middleware\Middleware;
 use Namelivia\Fitbit\OAuth\Constants\Constants;
 
 class Factory
 {
-    public function createClient(FileTokenPersistence $tokenPersistence, array $config)
+    public function createClient(TokenPersistenceInterface $tokenPersistence, array $config)
     {
         $oauth = new Middleware(
             new Client(['base_uri' => Constants::TOKEN_URL]),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,17 +8,16 @@ use Namelivia\Fitbit\Api\Fitbit;
 use Namelivia\Fitbit\OAuth\Factory\Factory;
 use Namelivia\Fitbit\OAuth\Config\Config;
 use Namelivia\Fitbit\OAuth\Authorizator\Authorizator;
-use kamermans\OAuth2\Persistence\FileTokenPersistence;
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
 
 class ServiceProvider
 {
     public function build(
-        string $tokenPath,
+        TokenPersistenceInterface $tokenPersistence,
         string $clientId,
         string $clientSecret,
         string $redirectUrl
     ) {
-		$tokenPersistence = new FileTokenPersistence($tokenPath);
 		$config = new Config($clientId, $clientSecret, $redirectUrl);
 		$authorizator = new Authorizator($config, $tokenPersistence);
 		$client = (new Factory())->createClient(

--- a/tests/Feature/FeatureTest.php
+++ b/tests/Feature/FeatureTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Namelivia\Fitbit\Tests;
 
 use Namelivia\Fitbit\ServiceProvider;
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
+use Mockery;
 
 class FeatureTest extends TestCase
 {
@@ -18,11 +20,18 @@ class FeatureTest extends TestCase
      */
     public function testUnauthorizedApi()
     {
+		$tokenPersistence = Mockery::mock(TokenPersistenceInterface::class);
+		//TODO: Review this code on kamermans repo to see what is this doing and what params does it have
+		$tokenPersistence->shouldReceive('restoreToken')
+			->once()
+			->andReturn(null);
+		$tokenPersistence->shouldReceive('deleteToken')
+			->once()
+			->andReturn(null);
 		$clientId = 'clientId';
 		$clientSecret = 'clientSecret';
 		$redirectUrl = 'redirectUrl';
-		$tokenPath = '/tmp/token';
-		$fitbit = (new ServiceProvider())->build($tokenPath, $clientId, $clientSecret, $redirectUrl);
+		$fitbit = (new ServiceProvider())->build($tokenPersistence, $clientId, $clientSecret, $redirectUrl);
 		$fitbit->activities()->favorites()->get();
     }
 }


### PR DESCRIPTION
By using the  `TokenPersistenceInterface` instead of the `FileTokenPersistence` the token can be persisted in multiple persistence layers instead of being forced to be persisted on the filesystem.